### PR TITLE
Code compiles with Python 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,12 +71,25 @@ macros = [
     ('BT_USE_DOUBLE_PRECISION', '1'),
 ]
 
+# Choose the correct Python library to link with.
+major, minor = sys.version_info.major, sys.version_info.minor
+if major == 2:
+    # Python 2
+    libraries = ['boost_python']
+elif major == 3:
+    # Python 3
+    libraries = ['boost_python-py3{}'.format(minor)]
+else:
+    # Neither Python 2.x nor 3.x.
+    print('Python {}.x is not supported'.format(major))
+    sys.exit(1)
+del major, minor
 
 modules = [
     Extension(str('bullet'),  # hack for distutils string param in Extension
               sources=[s for s in find_sources(src_dirs)],
               define_macros=macros,
-              libraries=['boost_python'],
+              libraries=libraries,
               extra_compile_args=['-w'],
               include_dirs=include_dirs)
 ]

--- a/test_collision/test_shapes.py
+++ b/test_collision/test_shapes.py
@@ -305,7 +305,9 @@ class ConvexTestCase(unittest.TestCase):
     def test_get_supporting_vertex(self):
         """Runtime tests only"""
         self.v2 = self.hull.local_get_supporting_vertex_without_margin(self.v1)
-        self.assertGreater(self.v1, self.v2)
+        self.assertGreater(self.v1.x, self.v2.x)
+        self.assertGreater(self.v1.y, self.v2.y)
+        self.assertGreater(self.v1.z, self.v2.z)
         self.v2 = self.hull.local_get_supporting_vertex_without_margin(self.v1)
         self.v3 = self.v2
         self.assertEquals(self.v2, bullet.btVector3(-1, -1, -1))


### PR DESCRIPTION
Hi, thank you for creating the elegant boost-python-bullet
bindings. With only a few minor changes I managed to compile it for
Python 2 & 3 on Ubuntu 14.04. All tests still pass. I thought you
might be interested.

Best, Oli
